### PR TITLE
ansible/ansible's stable-2.11 branch has been created.

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -20,6 +20,7 @@ jobs:
           # Testing against `devel` may fail as new tests are added.
           - stable-2.9
           - stable-2.10
+          - stable-2.11
           - devel
     runs-on: ubuntu-latest
     steps:
@@ -59,6 +60,7 @@ jobs:
         ansible:
           - stable-2.9
           - stable-2.10
+          - stable-2.11
           - devel
         python:
           - 2.6

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This collection provides some useful roles for retrieving ACME certificates.
 
 ## Tested with Ansible
 
-This collection is tested with Ansible 2.9, ansible-base 2.10 and ansible-core's `devel` branch.
-This collection requires Ansible 2.9.10 or newer.
+Tested with the current Ansible 2.9, ansible-base 2.10 and ansible-core 2.11 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 


### PR DESCRIPTION
Makes the necessary adjustments to CI.

When stable-2.11 is actually branched:
1. Rebase
2. `cp tests/sanity/ignore-2.11.txt tests/sanity/ignore-2.12.txt ; git add tests/sanity/ignore-2.12.txt ; git commit --amend ; git push -f`
