### PR TITLE
Remove tags from acme_certificate

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,7 +4,6 @@ skip_list:
   - meta-no-info  # Role info should contain platforms
   - ignore-errors  # Use failed_when and specify error conditions instead of using ignore_errors
   - var-naming  # Task uses 'set_fact' to define variables that violates variable naming standards
-  - no-log-password  # password should not be logged. [TBH this rule should not have been added to ansible-lint in the first place]
 exclude_paths:
   - changelogs/
 mock_modules:

--- a/README.acme_certificate.md
+++ b/README.acme_certificate.md
@@ -22,6 +22,7 @@ These are the main variables used by the `felixfontein.acme.acme_certificate` ro
 - `acme_certificate_keys_old_path`: Where old keys and certificates should be copied to; used in case `acme_certificate_keys_old_store` is true. Default value is `"keys/old/"`.
 - `acme_certificate_keys_old_store`: If set to `true`, will make copies of old keys and certificates. The copies will be stored in the directory specified by `acme_certificate_keys_old_store`. Default value is `false`.
 - `acme_certificate_keys_old_prepend_timestamp`: Whether copies of old keys and certificates should be prepended by the current date and time. Default value is `false`.
+- `acme_certificate_regenerate_private_keys`: Whether to regenerate private keys. Default value is `true`.
 - `acme_certificate_use_sops_for_key`: Use [Mozilla sops](https://github.com/mozilla/sops) to encrypt private key. Needs `.sops.yaml` file inside the keys directory or somewhere up the directory chain. Default value is `false`.
 - `acme_certificate_ocsp_must_staple`: Whether a certificate with the OCSP Must Staple extension is requested. Default value is `false`.
 - `acme_certificate_terms_agreed`: Whether the terms of services are accepted or not. Default value is `false`, usually needs to be set explicitly to `true` to allow creating an ACME account. This is only used for ACME v2.

--- a/changelogs/fragments/tags.yml
+++ b/changelogs/fragments/tags.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- "acme_certificate role - remove usage of tags ``issue-tls-certs``, ``issue-tls-certs-newkey`` and ``verify-tls-certs``. By default, new private keys are generated. This can be disabled by setting ``acme_certificate_regenerate_private_keys`` to ``false`` (https://github.com/felixfontein/ansible-acme/pull/15)."

--- a/docs/docsite/rst/acme_certificate_role.rst
+++ b/docs/docsite/rst/acme_certificate_role.rst
@@ -26,6 +26,7 @@ These are the main variables used by this role:
 - ``acme_certificate_keys_old_path``: Where old keys and certificates should be copied to; used in case ``acme_certificate_keys_old_store`` is true. Default value is ``"keys/old/"``.
 - ``acme_certificate_keys_old_store``: If set to ``true``, will make copies of old keys and certificates. The copies will be stored in the directory specified by ``acme_certificate_keys_old_store``. Default value is ``false``.
 - ``acme_certificate_keys_old_prepend_timestamp``: Whether copies of old keys and certificates should be prepended by the current date and time. Default value is ``false``.
+- ``acme_certificate_regenerate_private_keys``: Whether to regenerate private keys. Default value is ``true``.
 - ``acme_certificate_use_sops_for_key``: Use `Mozilla sops <https://github.com/mozilla/sops>`_ to encrypt private key. Needs ``.sops.yaml`` file inside the keys directory or somewhere up the directory chain. Default value is ``false``.
 - ``acme_certificate_ocsp_must_staple``: Whether a certificate with the OCSP Must Staple extension is requested. Default value is ``false``.
 - ``acme_certificate_terms_agreed``: Whether the terms of services are accepted or not. Default value is ``false``, usually needs to be set explicitly to ``true`` to allow creating an ACME account. This is only used for ACME v2.

--- a/roles/acme_certificate/defaults/main.yml
+++ b/roles/acme_certificate/defaults/main.yml
@@ -8,6 +8,7 @@ acme_certificate_keys_path: keys/
 acme_certificate_keys_old_path: keys/old/
 acme_certificate_keys_old_store: false
 acme_certificate_keys_old_prepend_timestamp: false
+acme_certificate_regenerate_private_keys: true
 acme_certificate_ocsp_must_staple: false
 acme_certificate_terms_agreed: true
 acme_certificate_acme_directory: https://acme-v02.api.letsencrypt.org/directory

--- a/roles/acme_certificate/meta/argument_specs.yml
+++ b/roles/acme_certificate/meta/argument_specs.yml
@@ -42,6 +42,14 @@ argument_specs:
         default: /var/www/challenges
         description:
           - Location where C(.well-known/acme-challenge/) will be served from.
+      acme_certificate_regenerate_private_keys:
+        type: bool
+        default: true
+        description:
+          - Whether to regenerate private keys.
+          - It is recommended to regularly create new private keys instead of re-using the existing ones forever.
+            The easiest way to ensure this is to simply regenerate them when the certificates are regenerated.
+          - If you use public key pinning, make sure to set this to C(false)!
       acme_certificate_http_become:
         type: bool
         default: false

--- a/roles/acme_certificate/tasks/dns-ansibletest-cleanup.yml
+++ b/roles/acme_certificate/tasks/dns-ansibletest-cleanup.yml
@@ -7,6 +7,3 @@
   delegate_to: localhost
   run_once: true
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data_dns | default({}) }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs

--- a/roles/acme_certificate/tasks/dns-ansibletest-create.yml
+++ b/roles/acme_certificate/tasks/dns-ansibletest-create.yml
@@ -9,6 +9,3 @@
   delegate_to: localhost
   run_once: true
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data_dns }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs

--- a/roles/acme_certificate/tasks/dns-hosttech-cleanup.yml
+++ b/roles/acme_certificate/tasks/dns-hosttech-cleanup.yml
@@ -15,6 +15,3 @@
   delegate_to: localhost
   run_once: true
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data_dns | default({}) }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs

--- a/roles/acme_certificate/tasks/dns-hosttech-create.yml
+++ b/roles/acme_certificate/tasks/dns-hosttech-create.yml
@@ -15,9 +15,6 @@
   delegate_to: localhost
   run_once: true
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data_dns }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs
 
 - name: Wait for DNS entries to propagate
   community.dns.wait_for_txt:

--- a/roles/acme_certificate/tasks/dns-ns1-cleanup.yml
+++ b/roles/acme_certificate/tasks/dns-ns1-cleanup.yml
@@ -11,6 +11,3 @@
   run_once: true
   when: "'_acme-challenge' in item.key"
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data_dns | default({}) }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs

--- a/roles/acme_certificate/tasks/dns-route53-cleanup.yml
+++ b/roles/acme_certificate/tasks/dns-route53-cleanup.yml
@@ -14,6 +14,3 @@
   delegate_to: localhost
   run_once: true
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data_dns | default({}) }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs

--- a/roles/acme_certificate/tasks/dns-route53-create.yml
+++ b/roles/acme_certificate/tasks/dns-route53-create.yml
@@ -15,9 +15,6 @@
   delegate_to: localhost
   run_once: true
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data_dns }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs
 
 - name: Wait for DNS entries to propagate
   community.dns.wait_for_txt:

--- a/roles/acme_certificate/tasks/http-cleanup-ansibletest.yml
+++ b/roles/acme_certificate/tasks/http-cleanup-ansibletest.yml
@@ -10,6 +10,3 @@
   delegate_to: localhost
   run_once: true
   with_dict: "{{ acme_certificate_INTERNAL_challenge.get('challenge_data', {}) }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs

--- a/roles/acme_certificate/tasks/http-cleanup.yml
+++ b/roles/acme_certificate/tasks/http-cleanup.yml
@@ -10,6 +10,3 @@
     state: absent
   with_dict: "{{ acme_certificate_INTERNAL_challenge.get('challenge_data', {}) }}"
   become: "{{ acme_certificate_http_become }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs

--- a/roles/acme_certificate/tasks/http-create-ansibletest.yml
+++ b/roles/acme_certificate/tasks/http-create-ansibletest.yml
@@ -14,6 +14,3 @@
   delegate_to: localhost
   run_once: true
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs

--- a/roles/acme_certificate/tasks/http-create.yml
+++ b/roles/acme_certificate/tasks/http-create.yml
@@ -8,9 +8,6 @@
     group: "{{ acme_certificate_http_challenge_group }}"
     mode: "{{ acme_certificate_http_challenge_folder_mode }}"
   become: "{{ acme_certificate_http_become }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs
 
 # Create challenge files on server.
 - name: "Copying challenge files for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
@@ -26,6 +23,3 @@
     mode: "{{ acme_certificate_http_challenge_file_mode }}"
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data }}"
   become: "{{ acme_certificate_http_become }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs

--- a/roles/acme_certificate/tasks/main.yml
+++ b/roles/acme_certificate/tasks/main.yml
@@ -1,73 +1,79 @@
 ---
-- name: Determine whether to force private key regeneration (1/2)
-  set_fact:
-    acme_certificate_INTERNAL_force_regenerate_private_key: false
-  tags:
-  - always
+- name: Sanity checks (1/2)
+  ansible.builtin.assert:
+    that: "acme_certificate_challenge != 'dns-01' or acme_certificate_dns_provider is not undefined"
+    msg: "acme_certificate_dns_provider must be defined for dns-01 DNS challenge"
+  run_once: true
 
-- name: Determine whether to force private key regeneration (2/2)
-  set_fact:
-    acme_certificate_INTERNAL_force_regenerate_private_key: true
-  tags:
-  - issue-tls-certs-newkey
+- name: Sanity checks (2/2)
+  ansible.builtin.assert:
+    that: "acme_certificate_domains or acme_certificate_ips"
+    msg: "acme_certificate_domains or acme_certificate_ips must be specified"
+  run_once: true
+
+# Sanity checks for DNS providers
+- include_tasks: dns-{{ acme_certificate_dns_provider }}-sanity.yml
+  when: "acme_certificate_challenge == 'dns-01'"
+
+- name: "Test whether old certificate files for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }} exist"
+  ansible.builtin.stat:
+    path: "{{ [acme_certificate_keys_path, acme_certificate_key_name] | community.general.path_join }}.pem"
+  delegate_to: localhost
+  register: acme_certificate_INTERNAL_old_certificate_exists
+  when: "acme_certificate_keys_old_store"
+  run_once: true
+
+- name: "Copying old certificate files for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
+  ansible.builtin.copy:
+    src: "{{ [acme_certificate_keys_path, acme_certificate_key_name] | community.general.path_join }}{{ item }}"
+    dest: >-
+      {{ [
+        acme_certificate_keys_old_path,
+        (
+          (ansible_date_time.date ~ '-' ~ ansible_date_time.hour ~ ansible_date_time.minute ~ ansible_date_time.second ~ '-')
+          if acme_certificate_keys_old_prepend_timestamp else ''
+        ) ~ acme_certificate_key_name ~ item
+      ] | community.general.path_join }}
+    mode: preserve
+  delegate_to: localhost
+  loop:
+  - "-chain.pem"
+  - "-fullchain.pem"
+  - "-rootchain.pem"
+  - "-root.pem"
+  - "{{ '.key.sops' if acme_certificate_use_sops_for_key else '.key' }}"
+  - ".pem"
+  when: "acme_certificate_keys_old_store and acme_certificate_INTERNAL_old_certificate_exists.stat.exists"
+  run_once: true
+
+- name: "Creating private key for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
+  community.crypto.openssl_privatekey:
+    path: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '.key'] | community.general.path_join }}"
+    mode: "{{ acme_certificate_privatekey_mode }}"
+    type: "{{ 'RSA' if acme_certificate_algorithm == 'rsa' else 'ECC' }}"
+    size: "{{ acme_certificate_key_length if acme_certificate_algorithm == 'rsa' else omit }}"
+    curve: >-
+      {{ omit if acme_certificate_algorithm == 'rsa' else
+         'secp256r1' if acme_certificate_algorithm == 'p-256' else
+         'secp384r1' if acme_certificate_algorithm == 'p-384' else
+         'secp521r1' if acme_certificate_algorithm == 'p-521' else
+         'invalid value for acme_certificate_algorithm!' }}
+    force: "{{ acme_certificate_regenerate_private_keys }}"
+  when: not acme_certificate_use_sops_for_key
+  delegate_to: localhost
+  run_once: true
 
 - block:
-  - name: Sanity checks (1/2)
-    ansible.builtin.assert:
-      that: "acme_certificate_challenge != 'dns-01' or acme_certificate_dns_provider is not undefined"
-      msg: "acme_certificate_dns_provider must be defined for dns-01 DNS challenge"
-    run_once: true
-
-  - name: Sanity checks (2/2)
-    ansible.builtin.assert:
-      that: "acme_certificate_domains or acme_certificate_ips"
-      msg: "acme_certificate_domains or acme_certificate_ips must be specified"
-    run_once: true
-
-  # Sanity checks for DNS providers
-  - include_tasks: dns-{{ acme_certificate_dns_provider }}-sanity.yml
-    when: "acme_certificate_challenge == 'dns-01'"
-
-  - name: "Test whether old certificate files for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }} exist"
-    ansible.builtin.stat:
-      path: "{{ [acme_certificate_keys_path, acme_certificate_key_name] | community.general.path_join }}.pem"
-    delegate_to: localhost
-    register: acme_certificate_INTERNAL_old_certificate_exists
-    when: "acme_certificate_keys_old_store"
-    run_once: true
-
-  - name: "Copying old certificate files for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
-    ansible.builtin.copy:
-      src: "{{ [acme_certificate_keys_path, acme_certificate_key_name] | community.general.path_join }}{{ item }}"
-      dest: >-
-        {{ [
-          acme_certificate_keys_old_path,
-          (
-            (ansible_date_time.date ~ '-' ~ ansible_date_time.hour ~ ansible_date_time.minute ~ ansible_date_time.second ~ '-')
-            if acme_certificate_keys_old_prepend_timestamp else ''
-          ) ~ acme_certificate_key_name ~ item
-        ] | community.general.path_join }}
-      mode: preserve
-    delegate_to: localhost
-    loop:
-    - "-chain.pem"
-    - "-fullchain.pem"
-    - "-rootchain.pem"
-    - "-root.pem"
-    - "{{ '.key.sops' if acme_certificate_use_sops_for_key else '.key' }}"
-    - ".pem"
-    when: "acme_certificate_keys_old_store and acme_certificate_INTERNAL_old_certificate_exists.stat.exists"
-    run_once: true
-
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs
-
-- block:
-  - name: "Creating private key for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
-    community.crypto.openssl_privatekey:
-      path: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '.key'] | community.general.path_join }}"
-      mode: "{{ acme_certificate_privatekey_mode }}"
+  - name: "Creating private key for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }} (sops encrypted)"
+    community.crypto.openssl_privatekey_pipe:
+      content: >-
+        {{
+          lookup(
+              'community.sops.sops',
+              [acme_certificate_keys_path, acme_certificate_key_name ~ '.key.sops'] | community.general.path_join,
+              empty_on_not_exist=true
+          ) | default(omit, true)
+          if not acme_certificate_regenerate_private_keys else omit }}
       type: "{{ 'RSA' if acme_certificate_algorithm == 'rsa' else 'ECC' }}"
       size: "{{ acme_certificate_key_length if acme_certificate_algorithm == 'rsa' else omit }}"
       curve: >-
@@ -76,161 +82,133 @@
            'secp384r1' if acme_certificate_algorithm == 'p-384' else
            'secp521r1' if acme_certificate_algorithm == 'p-521' else
            'invalid value for acme_certificate_algorithm!' }}
-      force: "{{ acme_certificate_INTERNAL_force_regenerate_private_key }}"
-    when: not acme_certificate_use_sops_for_key
-    delegate_to: localhost
-    run_once: true
+    no_log: true
+    register: acme_certificate_INTERNAL_private_key
 
-  - block:
-    - name: "Creating private key for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }} (sops encrypted)"
-      community.crypto.openssl_privatekey_pipe:
-        content: >-
-          {{
-            lookup(
-                'community.sops.sops',
-                [acme_certificate_keys_path, acme_certificate_key_name ~ '.key.sops'] | community.general.path_join,
-                empty_on_not_exist=true
-            ) | default(omit, true)
-            if not acme_certificate_INTERNAL_force_regenerate_private_key else omit }}
-        type: "{{ 'RSA' if acme_certificate_algorithm == 'rsa' else 'ECC' }}"
-        size: "{{ acme_certificate_key_length if acme_certificate_algorithm == 'rsa' else omit }}"
-        curve: >-
-          {{ omit if acme_certificate_algorithm == 'rsa' else
-             'secp256r1' if acme_certificate_algorithm == 'p-256' else
-             'secp384r1' if acme_certificate_algorithm == 'p-384' else
-             'secp521r1' if acme_certificate_algorithm == 'p-521' else
-             'invalid value for acme_certificate_algorithm!' }}
-      no_log: true
-      register: acme_certificate_INTERNAL_private_key
+  - name: "Store sops-encrypted private key for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
+    community.sops.sops_encrypt:
+      path: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '.key.sops'] | community.general.path_join }}"
+      content_text: "{{ acme_certificate_INTERNAL_private_key.privatekey }}"
+    when: acme_certificate_INTERNAL_private_key.changed
 
-    - name: "Store sops-encrypted private key for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
-      community.sops.sops_encrypt:
-        path: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '.key.sops'] | community.general.path_join }}"
-        content_text: "{{ acme_certificate_INTERNAL_private_key.privatekey }}"
-      when: acme_certificate_INTERNAL_private_key.changed
+  always:
+  - set_fact:
+      acme_certificate_INTERNAL_private_key: ''
 
-    always:
-    - set_fact:
-        acme_certificate_INTERNAL_private_key: ''
+  when: acme_certificate_use_sops_for_key
+  delegate_to: localhost
+  run_once: true
 
-    when: acme_certificate_use_sops_for_key
-    delegate_to: localhost
-    run_once: true
+- name: "Creating CSR for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
+  community.crypto.openssl_csr_pipe:
+    privatekey_content: >-
+      {{ lookup(
+           'community.sops.sops', [acme_certificate_keys_path, acme_certificate_key_name ~ '.key.sops']
+           | community.general.path_join)
+         if acme_certificate_use_sops_for_key else omit }}
+    privatekey_path: >-
+      {{ omit if acme_certificate_use_sops_for_key else
+         [acme_certificate_keys_path, acme_certificate_key_name ~ '.key'] | community.general.path_join }}
+    # noqa var-spacing - The problem is that the space eating in the following YAML string will result in `{{(acme...`
+    subject_alt_name: |
+        {{
+          (acme_certificate_domains | map('regex_replace', '^(.*)$', 'DNS:\1' ) | list)
+          + (acme_certificate_ips | map('regex_replace', '^(.*)$', 'IP:\1' ) | list)
+        }}
+    ocsp_must_staple: "{{ acme_certificate_ocsp_must_staple }}"
+    use_common_name_for_san: false
+  register: acme_certificate_INTERNAL_csr
+  delegate_to: localhost
+  run_once: true
 
-  - name: "Creating CSR for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
-    community.crypto.openssl_csr_pipe:
-      privatekey_content: >-
-        {{ lookup(
-             'community.sops.sops', [acme_certificate_keys_path, acme_certificate_key_name ~ '.key.sops']
-             | community.general.path_join)
-           if acme_certificate_use_sops_for_key else omit }}
-      privatekey_path: >-
-        {{ omit if acme_certificate_use_sops_for_key else
-           [acme_certificate_keys_path, acme_certificate_key_name ~ '.key'] | community.general.path_join }}
-      # noqa var-spacing - The problem is that the space eating in the following YAML string will result in `{{(acme...`
-      subject_alt_name: |
-          {{
-            (acme_certificate_domains | map('regex_replace', '^(.*)$', 'DNS:\1' ) | list)
-            + (acme_certificate_ips | map('regex_replace', '^(.*)$', 'IP:\1' ) | list)
-          }}
-      ocsp_must_staple: "{{ acme_certificate_ocsp_must_staple }}"
-      use_common_name_for_san: false
-    register: acme_certificate_INTERNAL_csr
-    delegate_to: localhost
-    run_once: true
+- name: "Get root certificate for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
+  ansible.builtin.get_url:
+    url: "{{ acme_certificate_root_certificate }}"
+    dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-root.pem'] | community.general.path_join }}"
+    force: true
+    validate_certs: "{{ acme_certificate_validate_certs }}"
+  delegate_to: localhost
+  run_once: true
 
-  - name: "Get root certificate for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
-    ansible.builtin.get_url:
-      url: "{{ acme_certificate_root_certificate }}"
-      dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-root.pem'] | community.general.path_join }}"
+- block:
+  - name: "Preparing challenges for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
+    community.crypto.acme_certificate:
+      account_key: "{{ acme_certificate_acme_account | default(omit) }}"
+      account_key_content: "{{ acme_certificate_acme_account_content | default(omit) }}"
+      account_uri: "{{ acme_certificate_acme_account_uri | default(omit) }}"
+      modify_account: "{{ acme_certificate_modify_account }}"
+      csr_content: "{{ acme_certificate_INTERNAL_csr.csr }}"
+      dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '.pem'] | community.general.path_join }}"
+      fullchain_dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-fullchain.pem'] | community.general.path_join }}"
+      chain_dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-chain.pem'] | community.general.path_join }}"
+      account_email: "{{ acme_certificate_acme_email | default(omit) }}"
+      terms_agreed: "{{ acme_certificate_terms_agreed }}"
+      challenge: "{{ acme_certificate_challenge }}"
+      acme_directory: "{{ acme_certificate_acme_directory }}"
+      acme_version: "{{ acme_certificate_acme_version }}"
       force: true
       validate_certs: "{{ acme_certificate_validate_certs }}"
     delegate_to: localhost
     run_once: true
+    register: acme_certificate_INTERNAL_challenge
 
-  - block:
-    - name: "Preparing challenges for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
-      community.crypto.acme_certificate:
-        account_key: "{{ acme_certificate_acme_account | default(omit) }}"
-        account_key_content: "{{ acme_certificate_acme_account_content | default(omit) }}"
-        account_uri: "{{ acme_certificate_acme_account_uri | default(omit) }}"
-        modify_account: "{{ acme_certificate_modify_account }}"
-        csr_content: "{{ acme_certificate_INTERNAL_csr.csr }}"
-        dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '.pem'] | community.general.path_join }}"
-        fullchain_dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-fullchain.pem'] | community.general.path_join }}"
-        chain_dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-chain.pem'] | community.general.path_join }}"
-        account_email: "{{ acme_certificate_acme_email | default(omit) }}"
-        terms_agreed: "{{ acme_certificate_terms_agreed }}"
-        challenge: "{{ acme_certificate_challenge }}"
-        acme_directory: "{{ acme_certificate_acme_directory }}"
-        acme_version: "{{ acme_certificate_acme_version }}"
-        force: true
-        validate_certs: "{{ acme_certificate_validate_certs }}"
-      delegate_to: localhost
-      run_once: true
-      register: acme_certificate_INTERNAL_challenge
+  always:
+  - ansible.builtin.debug:
+      msg: >-
+        account URI: {{ acme_certificate_INTERNAL_challenge.get('account_uri') }};
+        order URI: {{ acme_certificate_INTERNAL_challenge.get('order_uri') }}
+    run_once: true
 
-    always:
-    - ansible.builtin.debug:
-        msg: >-
-          account URI: {{ acme_certificate_INTERNAL_challenge.get('account_uri') }};
-          order URI: {{ acme_certificate_INTERNAL_challenge.get('order_uri') }}
-      run_once: true
+- block:
+  # Set up HTTP challenges
+  - include_tasks: http-create{{ '-ansibletest' if acme_certificate_INTERNAL_ansibletest | default(false) else '' }}.yml
+    when: "acme_certificate_challenge == 'http-01'"
 
-  - block:
-    # Set up HTTP challenges
-    - include_tasks: http-create{{ '-ansibletest' if acme_certificate_INTERNAL_ansibletest | default(false) else '' }}.yml
-      when: "acme_certificate_challenge == 'http-01'"
+  # Set up DNS challenges
+  - include_tasks: dns-{{ acme_certificate_dns_provider }}-create.yml
+    when: "acme_certificate_challenge == 'dns-01'"
 
-    # Set up DNS challenges
-    - include_tasks: dns-{{ acme_certificate_dns_provider }}-create.yml
-      when: "acme_certificate_challenge == 'dns-01'"
+  - name: "Getting certificates for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
+    community.crypto.acme_certificate:
+      account_key: "{{ acme_certificate_acme_account | default(omit) }}"
+      account_key_content: "{{ acme_certificate_acme_account_content | default(omit) }}"
+      account_uri: "{{ acme_certificate_acme_account_uri | default(omit) }}"
+      modify_account: "{{ acme_certificate_modify_account }}"
+      csr_content: "{{ acme_certificate_INTERNAL_csr.csr }}"
+      dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '.pem'] | community.general.path_join }}"
+      fullchain_dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-fullchain.pem'] | community.general.path_join }}"
+      chain_dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-chain.pem'] | community.general.path_join }}"
+      account_email: "{{ acme_certificate_acme_email | default(omit) }}"
+      terms_agreed: "{{ acme_certificate_terms_agreed }}"
+      challenge: "{{ acme_certificate_challenge }}"
+      acme_directory: "{{ acme_certificate_acme_directory }}"
+      acme_version: "{{ acme_certificate_acme_version }}"
+      force: true
+      data: "{{ acme_certificate_INTERNAL_challenge }}"
+      deactivate_authzs: "{{ acme_certificate_deactivate_authzs }}"
+      validate_certs: "{{ acme_certificate_validate_certs }}"
+      select_chain: "{{ acme_certificate_select_chain | default(omit) }}"
+    delegate_to: localhost
+    run_once: true
 
-    - name: "Getting certificates for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
-      community.crypto.acme_certificate:
-        account_key: "{{ acme_certificate_acme_account | default(omit) }}"
-        account_key_content: "{{ acme_certificate_acme_account_content | default(omit) }}"
-        account_uri: "{{ acme_certificate_acme_account_uri | default(omit) }}"
-        modify_account: "{{ acme_certificate_modify_account }}"
-        csr_content: "{{ acme_certificate_INTERNAL_csr.csr }}"
-        dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '.pem'] | community.general.path_join }}"
-        fullchain_dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-fullchain.pem'] | community.general.path_join }}"
-        chain_dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-chain.pem'] | community.general.path_join }}"
-        account_email: "{{ acme_certificate_acme_email | default(omit) }}"
-        terms_agreed: "{{ acme_certificate_terms_agreed }}"
-        challenge: "{{ acme_certificate_challenge }}"
-        acme_directory: "{{ acme_certificate_acme_directory }}"
-        acme_version: "{{ acme_certificate_acme_version }}"
-        force: true
-        data: "{{ acme_certificate_INTERNAL_challenge }}"
-        deactivate_authzs: "{{ acme_certificate_deactivate_authzs }}"
-        validate_certs: "{{ acme_certificate_validate_certs }}"
-        select_chain: "{{ acme_certificate_select_chain | default(omit) }}"
-      delegate_to: localhost
-      run_once: true
+  - name: "Form root chain for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
+    ansible.builtin.copy:
+      dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-rootchain.pem'] | community.general.path_join }}"
+      content: |
+        {{ lookup('file', [acme_certificate_keys_path, acme_certificate_key_name ~ '-root.pem'] | community.general.path_join) }}
+        {{ lookup('file', [acme_certificate_keys_path, acme_certificate_key_name ~ '-chain.pem'] | community.general.path_join) }}
+    delegate_to: localhost
+    run_once: true
+  always:
+  # Clean up HTTP challenges
+  - include_tasks: http-cleanup{{ '-ansibletest' if acme_certificate_INTERNAL_ansibletest | default(false) else '' }}.yml
+    when: "acme_certificate_challenge == 'http-01'"
 
-    - name: "Form root chain for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
-      ansible.builtin.copy:
-        dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-rootchain.pem'] | community.general.path_join }}"
-        content: |
-          {{ lookup('file', [acme_certificate_keys_path, acme_certificate_key_name ~ '-root.pem'] | community.general.path_join) }}
-          {{ lookup('file', [acme_certificate_keys_path, acme_certificate_key_name ~ '-chain.pem'] | community.general.path_join) }}
-      delegate_to: localhost
-      run_once: true
-    always:
-    # Clean up HTTP challenges
-    - include_tasks: http-cleanup{{ '-ansibletest' if acme_certificate_INTERNAL_ansibletest | default(false) else '' }}.yml
-      when: "acme_certificate_challenge == 'http-01'"
+  # Clean up DNS challenges
+  - include_tasks: dns-{{ acme_certificate_dns_provider }}-cleanup.yml
+    when: "acme_certificate_challenge == 'dns-01'"
 
-    # Clean up DNS challenges
-    - include_tasks: dns-{{ acme_certificate_dns_provider }}-cleanup.yml
-      when: "acme_certificate_challenge == 'dns-01'"
-
-    when: acme_certificate_INTERNAL_challenge is changed
-
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs
+  when: acme_certificate_INTERNAL_challenge is changed
 
 - name: "Verifying certificate for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
   # If you get strange failures here, upgrade to later versions of Ansible 2.9 / ansible-base 2.10.
@@ -252,7 +230,3 @@
   delegate_to: localhost
   run_once: true
   ignore_errors: "{{ not acme_certificate_verify_certs }}"
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs
-  - verify-tls-certs

--- a/roles/acme_certificate/tasks/main.yml
+++ b/roles/acme_certificate/tasks/main.yml
@@ -92,7 +92,8 @@
     when: acme_certificate_INTERNAL_private_key.changed
 
   always:
-  - set_fact:
+  - name: Remove private key data from Ansible facts
+    set_fact:
       acme_certificate_INTERNAL_private_key: ''
 
   when: acme_certificate_use_sops_for_key
@@ -153,7 +154,8 @@
     register: acme_certificate_INTERNAL_challenge
 
   always:
-  - ansible.builtin.debug:
+  - name: Show account and order URI
+    ansible.builtin.debug:
       msg: >-
         account URI: {{ acme_certificate_INTERNAL_challenge.get('account_uri') }};
         order URI: {{ acme_certificate_INTERNAL_challenge.get('order_uri') }}
@@ -192,7 +194,7 @@
     run_once: true
 
   - name: "Form root chain for {{ ', '.join(acme_certificate_domains + acme_certificate_ips) }}"
-    ansible.builtin.copy:
+    ansible.builtin.copy:  # noqa risky-file-permissions - use the user's umask
       dest: "{{ [acme_certificate_keys_path, acme_certificate_key_name ~ '-rootchain.pem'] | community.general.path_join }}"
       content: |
         {{ lookup('file', [acme_certificate_keys_path, acme_certificate_key_name ~ '-root.pem'] | community.general.path_join) }}


### PR DESCRIPTION
They are annoying :)

Allow to control private key regeneration behavior (new default: always regenerate) via new role parameter `acme_certificate_regenerate_private_keys`.
