### PR TITLE
Make ready for split-controller testing in ansible-core

### DIFF
--- a/tests/integration/targets/role_account_key_rollover-sops/aliases
+++ b/tests/integration/targets/role_account_key_rollover-sops/aliases
@@ -1,2 +1,3 @@
 shippable/cloud/group1
 cloud/acme
+context/controller

--- a/tests/integration/targets/role_account_key_rollover/aliases
+++ b/tests/integration/targets/role_account_key_rollover/aliases
@@ -1,2 +1,3 @@
 shippable/cloud/group1
 cloud/acme
+context/controller

--- a/tests/integration/targets/role_acme_certificate-sops/aliases
+++ b/tests/integration/targets/role_acme_certificate-sops/aliases
@@ -1,2 +1,3 @@
 shippable/cloud/group1
 cloud/acme
+context/controller

--- a/tests/integration/targets/role_acme_certificate/aliases
+++ b/tests/integration/targets/role_acme_certificate/aliases
@@ -1,2 +1,3 @@
 shippable/cloud/group1
 cloud/acme
+context/controller

--- a/tests/integration/targets/role_revoke_old_certificates/aliases
+++ b/tests/integration/targets/role_revoke_old_certificates/aliases
@@ -1,2 +1,3 @@
 shippable/cloud/group1
 cloud/acme
+context/controller


### PR DESCRIPTION
Uses ansible/ansible#75605 instead of devel in CI. Let's see what happens and if there are surprises :-)