### PR TITLE
acme_certificate: do not fail when acme_certificate_INTERNAL_old_privatekey_exists is failed or in another unexpected state

### DIFF
--- a/changelogs/fragments/38-acme-fail.yml
+++ b/changelogs/fragments/38-acme-fail.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid double failure of acme_certificate rescue task when first task in block fails (https://github.com/felixfontein/ansible-acme/pull/38)."

--- a/roles/acme_certificate/tasks/main.yml
+++ b/roles/acme_certificate/tasks/main.yml
@@ -116,7 +116,7 @@
       delegate_to: localhost
       when: >-
         not acme_certificate_INTERNAL_success
-        and acme_certificate_INTERNAL_old_privatekey_exists.stat.exists
+        and (acme_certificate_INTERNAL_old_privatekey_exists.stat.exists | default(false))
         and acme_certificate_INTERNAL_private_key_copy is defined
       run_once: true
 


### PR DESCRIPTION
Ref #37.