### PR TITLE
CI: install collections as test-deps via git

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -107,18 +107,13 @@ jobs:
           integration-retry-on-error: 'true'
           target-python-version: ${{ matrix.python }}
           testing-type: integration
-          pre-test-cmd: |-
-            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.crypto.git ../../community/crypto
-            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.dns.git ../../community/dns
-            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.general.git ../../community/general
-            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.sops.git ../../community/sops
-            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ../../community/internal_test_tools
-          # test-deps: >-
-          #   git+https://github.com/ansible-collections/community.crypto.git,main
-          #   git+https://github.com/ansible-collections/community.dns.git,main
-          #   git+https://github.com/ansible-collections/community.general.git,main
-          #   git+https://github.com/ansible-collections/community.sops.git,main
-          #   git+https://github.com/ansible-collections/community.internal_test_tools.git,main
+          # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
+          test-deps: >-
+            git+https://github.com/ansible-collections/community.crypto.git,main
+            git+https://github.com/ansible-collections/community.dns.git,main
+            git+https://github.com/ansible-collections/community.general.git,main
+            git+https://github.com/ansible-collections/community.sops.git,main
+            git+https://github.com/ansible-collections/community.internal_test_tools.git,main
 
   ansible-lint:
     name: ansible-lint

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install ansible-core and ansible-lint
         run: |
@@ -163,7 +163,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install yamllint
         run: |


### PR DESCRIPTION
Won't work as long as we support Ansible 2.9.