### PR TITLE
CI: Use ansible-community/eol-ansible for 2.9/2.10/2.11 tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Perform sanity testing
         uses: felixfontein/ansible-test-gh-action@main
         with:
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["stable-2.9", "stable-2.10", "stable-2.11"]'), matrix.ansible) && 'ansible-community/eol-ansible' || 'ansible/ansible' }}
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: sanity
 
@@ -106,6 +107,7 @@ jobs:
           under Python ${{ matrix.python }}
         uses: felixfontein/ansible-test-gh-action@main
         with:
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["stable-2.9", "stable-2.10", "stable-2.11"]'), matrix.ansible) && 'ansible-community/eol-ansible' || 'ansible/ansible' }}
           ansible-core-version: ${{ matrix.ansible }}
           integration-continue-on-error: 'false'
           integration-diff: 'false'


### PR DESCRIPTION
##### SUMMARY
This should fix the EOL CI. Or at least most of it...

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
