### PR TITLE
Don't create cloudflare challenge entries multiple times for same role

### DIFF
--- a/roles/acme_certificate/tasks/dns-cloudflare-create.yml
+++ b/roles/acme_certificate/tasks/dns-cloudflare-create.yml
@@ -16,6 +16,8 @@
     state: present
     ttl: 60
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data_dns }}"
+  delegate_to: localhost
+  run_once: true
 
 - name: Wait for DNS entries to propagate
   community.dns.wait_for_txt:


### PR DESCRIPTION
Current version of Cloudflare DNS challenge script tries to create DNS challenge entries from each host, which produces API errors when there are multiple hosts. This is due to missing delegate_to and run_once declarations within the task. When I look at other scripts where DNS challenge entries are created, they all have delegate_to and run_once delegations.