### PR TITLE
Use community.crypto's stable-2 branch for ansible-core < 2.17

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -1,6 +1,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-# SPDX-FileCopyrightText: 2020, Felix Fontein
+# SPDX-FileCopyrightText: 2025, Felix Fontein
 
 [collection_sources]
 "amazon.aws" = "git+https://github.com/ansible-collections/amazon.aws.git,main"
@@ -11,6 +11,24 @@
 "community.sops" = "git+https://github.com/ansible-collections/community.sops.git,main"
 "community.internal_test_tools" = "git+https://github.com/ansible-collections/community.internal_test_tools.git,main"
 "community.library_inventory_filtering" = "git+https://github.com/ansible-collections/community.library_inventory_filtering.git,stable-1"
+
+[collection_sources_per_ansible.'2.11']
+"community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"
+
+[collection_sources_per_ansible.'2.12']
+"community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"
+
+[collection_sources_per_ansible.'2.13']
+"community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"
+
+[collection_sources_per_ansible.'2.14']
+"community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"
+
+[collection_sources_per_ansible.'2.15']
+"community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"
+
+[collection_sources_per_ansible.'2.16']
+"community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"
 
 [sessions]
 


### PR DESCRIPTION
Needs https://github.com/ansible-community/antsibull-nox/pull/77 to be merged.

(Due to how shared workflows work, I cannot simply point the shared workflow to that branch. It will - unfortunately - still use antsibull-nox from the `main` branch. See https://github.com/ansible-community/github-docs-build/issues/4 and https://github.com/ansible-community/github-docs-build/issues/29.)