### PR TITLE
Support Hetzner's new DNS API

### DIFF
--- a/changelogs/fragments/109-hetzner.yml
+++ b/changelogs/fragments/109-hetzner.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Support Hetzner's new DNS API (https://github.com/felixfontein/ansible-acme/pull/109)."

--- a/docs/docsite/rst/general_role_parameters.rst
+++ b/docs/docsite/rst/general_role_parameters.rst
@@ -94,7 +94,7 @@ If DNS challenges are used, the following variables define how the challenges ca
 
 - ``acme_certificate_dns_provider``: must be one of ``route53``, ``hetzner``, ``hosttech``, ``ns1``, ``inwx``, and ``cloudflare``. Each needs more information:
   - For ``route53`` (`Amazon Route 53 <https://aws.amazon.com/route53/>`_), the credentials must be passed as ``acme_certificate_aws_access_key`` and ``acme_certificate_aws_secret_key``.
-  - For ``hetzner`` (`Hetzner GmbH <https://www.hetzner.com/>`_), the token has to be provided as ``acme_certificate_hetzner_token`` for the DNS API.
+  - For ``hetzner`` (`Hetzner GmbH <https://www.hetzner.com/>`_), the token has to be provided as ``acme_certificate_hetzner_token`` for the old DNS API, or as ``acme_certificate_hetzner_api_token`` for the new (end of 2025) DNS API.
   - For ``hosttech`` (`hosttech GmbH <https://www.hosttech.ch/>`_), the credentials have to be passed as ``acme_certificate_hosttech_username`` and ``acme_certificate_hosttech_password`` for using the old WSDL API, and ``acme_certificate_hosttech_token`` for the new JSON API.
   - For ``ns1`` (`ns1.com <https://ns1.com>`_) the key for your API account must be passed as ``acme_certificate_ns1_secret_key``. Also it depends on external module ``ns1_record``. See below for instructions on how to install these modules.
   - For ``inwx`` (`inwx.de <https://inwx.de>`_) the credentials have to be passed as ``acme_certificate_inwx_username`` and ``acme_certificate_inwx_password``. Please keep in mind that 2FA (two factor authentication) is currently not supported and needs do be disabled. Related Issue: (`inwx/ansible-collection#3 <https://github.com/inwx/ansible-collection/issues/3>`_)

--- a/roles/acme_certificate/meta/argument_specs.yml
+++ b/roles/acme_certificate/meta/argument_specs.yml
@@ -136,9 +136,21 @@ argument_specs:
       acme_certificate_hetzner_token:
         type: str
         description:
-          - When using O(acme_certificate_dns_provider=hetzner) with the Hetzner API, the API token must be passed in this option.
+          - When using O(acme_certificate_dns_provider=hetzner) with the Hetzner API, the API token must be passed in this option
+            if the old Hetzner DNS API is used.
           - When O(acme_certificate_verify_auth=false), this is not required when O(acme_certificate_dns_provider=hetzner) and
             can be provided in other ways, for example with R(module defaults, module_defaults).
+          - This is mutually exclusive with O(acme_certificate_hetzner_api_token).
+      acme_certificate_hetzner_api_token:
+        type: str
+        description:
+          - When using O(acme_certificate_dns_provider=hetzner) with the Hetzner API, the API token must be passed in this option
+            if the new (end of 2025) Hetzner DNS API is used.
+          - When O(acme_certificate_verify_auth=false), this is not required when O(acme_certificate_dns_provider=hetzner) and
+            can be provided in other ways, for example with R(module defaults, module_defaults).
+          - This is mutually exclusive with O(acme_certificate_hetzner_token).
+          - Note that this requires community.dns 3.5.0 or newer.
+        version_added: 0.11.0
       acme_certificate_ns1_secret_key:
         type: str
         description:

--- a/roles/acme_certificate/tasks/dns-hetzner-cleanup.yml
+++ b/roles/acme_certificate/tasks/dns-hetzner-cleanup.yml
@@ -14,6 +14,7 @@
     ttl: "60"
     value: "{{ item.value }}"
     hetzner_token: "{{ acme_certificate_hetzner_token | default(omit) }}"
+    hetzner_api_token: "{{ acme_certificate_hetzner_api_token | default(omit) }}"
   delegate_to: localhost
   run_once: true
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data_dns | default({}) }}"

--- a/roles/acme_certificate/tasks/dns-hetzner-create.yml
+++ b/roles/acme_certificate/tasks/dns-hetzner-create.yml
@@ -14,6 +14,7 @@
     ttl: "60"
     value: "{{ item.value }}"
     hetzner_token: "{{ acme_certificate_hetzner_token | default(omit) }}"
+    hetzner_api_token: "{{ acme_certificate_hetzner_api_token | default(omit) }}"
   delegate_to: localhost
   run_once: true
   with_dict: "{{ acme_certificate_INTERNAL_challenge.challenge_data_dns }}"

--- a/roles/acme_certificate/tasks/dns-hetzner-sanity.yml
+++ b/roles/acme_certificate/tasks/dns-hetzner-sanity.yml
@@ -6,9 +6,17 @@
 - name: DNS sanity checks (1/2)
   ansible.builtin.assert:
     that:
-      - acme_certificate_hetzner_token is defined
+      - >-
+        acme_certificate_hetzner_api_token is defined
+        or acme_certificate_hetzner_token is defined
+      - >-
+        not (
+          acme_certificate_hetzner_api_token is defined
+          and acme_certificate_hetzner_token is defined
+        )
     msg: >-
-      acme_certificate_hetzner_token must be specified for Hetzner DNS
+      acme_certificate_hetzner_api_token must be specified for Hetzner DNS (new API since end of 2025), or alternatively
+      acme_certificate_hetzner_token must be specified (old API)
   run_once: true
   when: acme_certificate_verify_auth
 
@@ -17,6 +25,9 @@
     that:
       - >
         lookup('community.general.collection_version', 'community.dns',
-               result_not_found='0.0.0', result_no_version='2.9.0') is version('2.9.0', '>=')
-    msg: "community.dns 2.9.0 or newer must be installed for Hetzner DNS"
+               result_not_found='0.0.0', result_no_version=min_version) is version(min_version, '>=')
+    msg: "community.dns {{ min_version }} or newer must be installed for Hetzner DNS"
   run_once: true
+  vars:
+    min_version: >-
+      {{ '3.5.0' if acme_certificate_hetzner_api_token is defined else '2.9.0' }}


### PR DESCRIPTION
Requires community.dns 3.5.0 or newer.